### PR TITLE
Add secure connection to ldap (and more) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,34 @@ openldap_scrape{result="ok"} 6985
 The binary itself is configured via command line flags:
 
 ```
-Usage of ./target/openldap_exporter:
+Usage of ./openldap_exporter-linux:
   -interval duration
-        Scrape interval (default 30s)
+    	Scrape interval (default 30s)
   -ldapAddr string
-        Address of OpenLDAP server (default "localhost:389")
-  -ldapPass string
-        OpenLDAP bind password (optional)
+    	Address of OpenLDAP server (default "ldap://localhost:389")
   -ldapUser string
-        OpenLDAP bind username (optional)
+    	OpenLDAP bind username (optional)
+  -ldapPass string
+    	OpenLDAP bind password (optional)
+  -ldapStartTLS
+    	Use start TLS (optional)
+  -ldapCACrt string
+    	Path to CA certificate for LDAPS (optional)
   -promAddr string
-        Bind address for prometheus HTTP metrics server (default ":9330")
+    	Bind address for prometheus HTTP metrics server (default ":9330")
   -version
-        Show version and exit
+    	Show version and exit
 ```
+
+`-ldapAddr` supports `ldaps://` and `ldap://` scheme uri's. (defaults to ldap:// scheme)  
+using the LDAPS scheme will open a connection using TLS.  
+To use StartTLS use ldap:// scheme and the command line flag `-ldapStartTLS`
+
+`-ldapCACrt` if the ldap server uses a custom CA certificate, add the path to the public CA Cert in PEM format  
+
+
+
+
 
 ## Building the exporter
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Usage of ./openldap_exporter-linux:
     	Path to CA certificate for LDAPS (optional)
   -promAddr string
     	Bind address for prometheus HTTP metrics server (default ":9330")
+  -promCrt string
+        Path to PEM Certificate (chain) file to run metrics server in https mode (optional, required if CrtKey is used)   
+  -promCrtKey string
+        Path to PEM Certificate Key file to run metrics server in https mode (optional, required if Crt is used)         
   -version
     	Show version and exit
 ```

--- a/code/src/app/exporter/cmd/openldap_exporter/main.go
+++ b/code/src/app/exporter/cmd/openldap_exporter/main.go
@@ -11,8 +11,8 @@ import (
 
 var (
 	promAddr 		= flag.String("promAddr", ":9330", "Bind address for prometheus HTTP metrics server")
-	promCrt 		= flag.String("promCrt", "", "Path to PEM Certificate (chain) file to run metrics server in https mode")
-	promCrtKey 		= flag.String("promCrtKey", "", "Path to PEM Certificate Key file to run metrics server in https mode")
+	promCrt 		= flag.String("promCrt", "", "Path to PEM Certificate (chain) file to run metrics server in https mode (optional, required if CrtKey is used)")
+	promCrtKey 		= flag.String("promCrtKey", "", "Path to PEM Certificate Key file to run metrics server in https mode (optional, required if Crt is used)")
 	ldapAddr 		= flag.String("ldapAddr", "ldap://localhost:389", "Address of OpenLDAP server")
 	ldapCACrt 		= flag.String("ldapCACrt", "", "Path to CA certificate for LDAPS (optional)")
 	ldapUser		= flag.String("ldapUser", "", "OpenLDAP bind username (optional)")

--- a/code/src/app/exporter/cmd/openldap_exporter/main.go
+++ b/code/src/app/exporter/cmd/openldap_exporter/main.go
@@ -6,25 +6,53 @@ import (
 	"log"
 	"os"
 	"time"
-
 	"app/exporter"
 )
 
 var (
-	promAddr = flag.String("promAddr", ":9330", "Bind address for prometheus HTTP metrics server")
-	ldapAddr = flag.String("ldapAddr", "localhost:389", "Address of OpenLDAP server")
-	ldapUser = flag.String("ldapUser", "", "OpenLDAP bind username (optional)")
-	ldapPass = flag.String("ldapPass", "", "OpenLDAP bind password (optional)")
-	interval = flag.Duration("interval", 30*time.Second, "Scrape interval")
-	version  = flag.Bool("version", false, "Show version and exit")
+	promAddr 		= flag.String("promAddr", ":9330", "Bind address for prometheus HTTP metrics server")
+	ldapAddr 		= flag.String("ldapAddr", "localhost:389", "Address of OpenLDAP server")
+	ldapCACrt 		= flag.String("ldapCACrt", "", "Path to CA certificate for LDAPS (optional)")
+	ldapUser		= flag.String("ldapUser", "", "OpenLDAP bind username (optional)")
+	ldapUseStartTLS = flag.Bool("ldapUseStartTLS", false, "Use start TLS (optional)")
+	ldapPass 		= flag.String("ldapPass", "", "OpenLDAP bind password (optional)")
+	interval 		= flag.Duration("interval", 30*time.Second, "Scrape interval")
+	version  		= flag.Bool("version", false, "Show version and exit")
 )
 
 func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Println(exporter.GetVersion())
+		fmt.Println("Version:", exporter.GetVersion())
 		os.Exit(0)
+	}
+
+	config := exporter.NewLDAPConfig()
+
+	/** Parse ldap address **/
+	err := config.ParseAddr(*ldapAddr)
+	if err != nil {
+		log.Println("Error parsing ldap address: ", err.Error())
+		os.Exit(1)
+	}
+
+	/** Load Certificate if given, and panic on error **/
+	if *ldapCACrt != "" {
+		err = config.LoadCACert(*ldapCACrt)
+		if err != nil {
+			log.Println("Error loading CA certificate file: ", err.Error())
+			os.Exit(1)
+		} else {
+			log.Println("Successfully loaded CA cert file:", *ldapCACrt)
+		}
+	}
+
+	config.Username = *ldapUser
+	config.Password = *ldapPass
+
+	if *ldapUseStartTLS {
+		config.UseStartTLS = true
 	}
 
 	log.Println("Starting prometheus HTTP metrics server on", *promAddr)
@@ -32,6 +60,6 @@ func main() {
 
 	log.Println("Starting OpenLDAP scraper for", *ldapAddr)
 	for range time.Tick(*interval) {
-		exporter.ScrapeMetrics(*ldapAddr, *ldapUser, *ldapPass)
+		exporter.ScrapeMetrics(&config)
 	}
 }

--- a/code/src/app/exporter/cmd/openldap_exporter/main.go
+++ b/code/src/app/exporter/cmd/openldap_exporter/main.go
@@ -11,11 +11,11 @@ import (
 
 var (
 	promAddr 		= flag.String("promAddr", ":9330", "Bind address for prometheus HTTP metrics server")
-	ldapAddr 		= flag.String("ldapAddr", "localhost:389", "Address of OpenLDAP server")
+	ldapAddr 		= flag.String("ldapAddr", "ldap://localhost:389", "Address of OpenLDAP server")
 	ldapCACrt 		= flag.String("ldapCACrt", "", "Path to CA certificate for LDAPS (optional)")
 	ldapUser		= flag.String("ldapUser", "", "OpenLDAP bind username (optional)")
-	ldapUseStartTLS = flag.Bool("ldapUseStartTLS", false, "Use start TLS (optional)")
 	ldapPass 		= flag.String("ldapPass", "", "OpenLDAP bind password (optional)")
+	ldapUseStartTLS = flag.Bool("ldapStartTLS", false, "Use start TLS (optional)")
 	interval 		= flag.Duration("interval", 30*time.Second, "Scrape interval")
 	version  		= flag.Bool("version", false, "Show version and exit")
 )

--- a/code/src/app/exporter/cmd/openldap_exporter/main.go
+++ b/code/src/app/exporter/cmd/openldap_exporter/main.go
@@ -1,25 +1,25 @@
 package main
 
 import (
+	"app/exporter"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"time"
-	"app/exporter"
 )
 
 var (
-	promAddr 		= flag.String("promAddr", ":9330", "Bind address for prometheus HTTP metrics server")
-	promCrt 		= flag.String("promCrt", "", "Path to PEM Certificate (chain) file to run metrics server in https mode (optional, required if CrtKey is used)")
-	promCrtKey 		= flag.String("promCrtKey", "", "Path to PEM Certificate Key file to run metrics server in https mode (optional, required if Crt is used)")
-	ldapAddr 		= flag.String("ldapAddr", "ldap://localhost:389", "Address of OpenLDAP server")
-	ldapCACrt 		= flag.String("ldapCACrt", "", "Path to CA certificate for LDAPS (optional)")
-	ldapUser		= flag.String("ldapUser", "", "OpenLDAP bind username (optional)")
-	ldapPass 		= flag.String("ldapPass", "", "OpenLDAP bind password (optional)")
+	promAddr        = flag.String("promAddr", ":9330", "Bind address for prometheus HTTP metrics server")
+	promCrt         = flag.String("promCrt", "", "Path to PEM Certificate (chain) file to run metrics server in https mode (optional, required if CrtKey is used)")
+	promCrtKey      = flag.String("promCrtKey", "", "Path to PEM Certificate Key file to run metrics server in https mode (optional, required if Crt is used)")
+	ldapAddr        = flag.String("ldapAddr", "ldap://localhost:389", "Address of OpenLDAP server")
+	ldapCACrt       = flag.String("ldapCACrt", "", "Path to CA certificate for LDAPS (optional)")
+	ldapUser        = flag.String("ldapUser", "", "OpenLDAP bind username (optional)")
+	ldapPass        = flag.String("ldapPass", "", "OpenLDAP bind password (optional)")
 	ldapUseStartTLS = flag.Bool("ldapStartTLS", false, "Use start TLS (optional)")
-	interval 		= flag.Duration("interval", 30*time.Second, "Scrape interval")
-	version  		= flag.Bool("version", false, "Show version and exit")
+	interval        = flag.Duration("interval", 30*time.Second, "Scrape interval")
+	version         = flag.Bool("version", false, "Show version and exit")
 )
 
 func main() {
@@ -29,7 +29,6 @@ func main() {
 		fmt.Println("Version:", exporter.GetVersion())
 		os.Exit(0)
 	}
-
 
 	config := exporter.NewLDAPConfig()
 
@@ -62,7 +61,6 @@ func main() {
 	serverConfig.Address = *promAddr
 	serverConfig.CertFile = *promCrt
 	serverConfig.KeyFile = *promCrtKey
-
 
 	log.Println("Starting prometheus HTTP(s) metrics server on", serverConfig.Address)
 	go exporter.StartMetricsServer(serverConfig)

--- a/code/src/app/exporter/scraper.go
+++ b/code/src/app/exporter/scraper.go
@@ -33,7 +33,6 @@ const (
 	SchemeLDAPS = "ldaps"
 	SchemeLDAP  = "ldap"
 	SchemeLDAPI = "ldapi"
-
 )
 
 type query struct {
@@ -44,25 +43,23 @@ type query struct {
 }
 
 type LDAPConfig struct {
-
 	UseTLS      bool
 	UseStartTLS bool
 	Scheme      string
 	Addr        string
-	Host		string
-	Port		string
+	Host        string
+	Port        string
 	Protocol    string
 	Username    string
 	Password    string
 	TLSConfig   tls.Config
-
 }
 
-func (config *LDAPConfig) ParseAddr(addr string) error{
+func (config *LDAPConfig) ParseAddr(addr string) error {
 
 	var u *url.URL
 
-	u,err := url.Parse(addr)
+	u, err := url.Parse(addr)
 	if (err != nil) {
 		// Well, so far the easy way....
 		u = &url.URL{}
@@ -72,13 +69,13 @@ func (config *LDAPConfig) ParseAddr(addr string) error{
 
 		if strings.HasPrefix(addr, SchemeLDAPI) {
 			u.Scheme = SchemeLDAPI
-			u.Host, _ = url.QueryUnescape(strings.Replace(addr, SchemeLDAPI + "://", "", 1))
+			u.Host, _ = url.QueryUnescape(strings.Replace(addr, SchemeLDAPI+"://", "", 1))
 		} else if strings.HasPrefix(addr, SchemeLDAPS) {
 			u.Scheme = SchemeLDAPS
-			u.Host = strings.Replace(addr, SchemeLDAPS + "://", "", 1)
+			u.Host = strings.Replace(addr, SchemeLDAPS+"://", "", 1)
 		} else {
 			u.Scheme = SchemeLDAP
-			u.Host = strings.Replace(addr, SchemeLDAP + "://", "", 1)
+			u.Host = strings.Replace(addr, SchemeLDAP+"://", "", 1)
 		}
 
 	}
@@ -102,7 +99,6 @@ func (config *LDAPConfig) ParseAddr(addr string) error{
 }
 
 func (config *LDAPConfig) LoadCACert(cafile string) error {
-	
 
 	if _, err := os.Stat(cafile); os.IsNotExist(err) {
 		return errors.New("CA Certificate file does not exists")
@@ -127,25 +123,22 @@ func (config *LDAPConfig) LoadCACert(cafile string) error {
 
 }
 
-
 func NewLDAPConfig() LDAPConfig {
 
 	conf := LDAPConfig{}
 
-	conf.Scheme 		= SchemeLDAP
-	conf.Host 			= "localhost"
-	conf.Port			= "389"
-	conf.Addr 			= conf.Host + ":" + conf.Port
-	conf.Protocol 		= "tcp"
-	conf.UseTLS 		= false
-	conf.UseStartTLS 	= false
-	conf.TLSConfig		= tls.Config{}
-
+	conf.Scheme = SchemeLDAP
+	conf.Host = "localhost"
+	conf.Port = "389"
+	conf.Addr = conf.Host + ":" + conf.Port
+	conf.Protocol = "tcp"
+	conf.UseTLS = false
+	conf.UseStartTLS = false
+	conf.TLSConfig = tls.Config{}
 
 	return conf
 
 }
-
 
 var (
 	monitoredObjectGauge = prometheus.NewGaugeVec(

--- a/code/src/app/exporter/server.go
+++ b/code/src/app/exporter/server.go
@@ -11,11 +11,9 @@ import (
 var version string
 
 type ServerConfig struct {
-
-	Address string
+	Address  string
 	CertFile string
-	KeyFile string
-
+	KeyFile  string
 }
 
 func GetVersion() string {

--- a/code/src/app/exporter/server.go
+++ b/code/src/app/exporter/server.go
@@ -10,16 +10,39 @@ import (
 
 var version string
 
+type ServerConfig struct {
+
+	Address string
+	CertFile string
+	KeyFile string
+
+}
+
 func GetVersion() string {
 	return version
 }
 
-func StartMetricsServer(bindAddr string) {
+func NewServerConfig() ServerConfig {
+
+	sc := ServerConfig{}
+
+	return sc
+
+}
+
+func StartMetricsServer(config ServerConfig) {
 	d := http.NewServeMux()
 	d.Handle("/metrics", promhttp.Handler())
 	d.HandleFunc("/version", showVersion)
 
-	err := http.ListenAndServe(bindAddr, d)
+	var err error
+
+	if config.CertFile != "" && config.KeyFile != "" {
+		err = http.ListenAndServeTLS(config.Address, config.CertFile, config.KeyFile, d)
+	} else {
+		err = http.ListenAndServe(config.Address, d)
+	}
+
 	if err != nil {
 		log.Fatal("Failed to start metrics server, error is:", err)
 	}


### PR DESCRIPTION
This PR solves multiple issues:

- support all ldap connection protocols:
  - ldap:// (Default unsecure connection)
  - ldap:// + startTLS (Secure connection using StartTLS) 
  - ldaps:// (Deprecated connection over TLS)
  - ldapi:// (Connection over linux socket)
- support use of public CA certificate for verification of LDAP server
- support running metrics endpoint over HTTPS by providing a PEM certificate chain file and key file
