### PR TITLE
Support for configuration through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ Usage of ./target/openldap_exporter:
         Show version and exit
 ```
 
+## Configuration through environment variables
+
+The binary can also be configured via environment variables. The same parameters
+can be set as with the command line flags. If both command line flags and
+environment variables are defined, command line flags take precedence.
+
+Mapping of command line flags to environment variables is shown in the table
+below:
+
+| Cmd Flag | Env Var     |
+|----------|-------------|
+| interval | INTERVAL    |
+| ldapAddr | LDAP\_ADDR  |
+| ldapPass | LDAP\_PASS  |
+| ldapUser | LDAP\_USER_ |
+| promAddr | PROM\_ADDR_ |
+
+Example:
+
+```
+LDAP_PASS=secret ./openldap_exporter --ldapUser test
+```
+
 ## Build
 
 1. Install Go 1.13 from https://golang.org/

--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ environment variables are defined, command line flags take precedence.
 Mapping of command line flags to environment variables is shown in the table
 below:
 
-| Cmd Flag | Env Var     |
-|----------|-------------|
-| interval | INTERVAL    |
-| ldapAddr | LDAP\_ADDR  |
-| ldapPass | LDAP\_PASS  |
-| ldapUser | LDAP\_USER_ |
-| promAddr | PROM\_ADDR_ |
+| Cmd Flag | Env Var    |
+|----------|------------|
+| interval | INTERVAL   |
+| ldapAddr | LDAP\_ADDR |
+| ldapPass | LDAP\_PASS |
+| ldapUser | LDAP\_USER |
+| promAddr | PROM\_ADDR |
 
 Example:
 

--- a/cmd/openldap_exporter/main.go
+++ b/cmd/openldap_exporter/main.go
@@ -11,13 +11,33 @@ import (
 )
 
 var (
-	promAddr = flag.String("promAddr", ":9330", "Bind address for prometheus HTTP metrics server")
-	ldapAddr = flag.String("ldapAddr", "localhost:389", "Address of OpenLDAP server")
-	ldapUser = flag.String("ldapUser", "", "OpenLDAP bind username (optional)")
-	ldapPass = flag.String("ldapPass", "", "OpenLDAP bind password (optional)")
-	interval = flag.Duration("interval", 30*time.Second, "Scrape interval")
+	promAddr = flag.String("promAddr", defaultEnvString("PROM_ADDR", ":9330"), "Bind address for prometheus HTTP metrics server")
+	ldapAddr = flag.String("ldapAddr", defaultEnvString("LDAP_ADDR", "localhost:389"), "Address of OpenLDAP server")
+	ldapUser = flag.String("ldapUser", defaultEnvString("LDAP_USER", ""), "OpenLDAP bind username (optional)")
+	ldapPass = flag.String("ldapPass", defaultEnvString("LDAP_PASS", ""), "OpenLDAP bind password (optional)")
+	interval = flag.Duration("interval", defaultEnvDuration("INTERVAL", 30*time.Second), "Scrape interval")
 	version  = flag.Bool("version", false, "Show version and exit")
 )
+
+func defaultEnvString(envName, defValue string) string {
+	envValue := os.Getenv(envName)
+	if envValue == "" {
+		return defValue
+	}
+	return envValue
+}
+
+func defaultEnvDuration(envName string, defValue time.Duration) time.Duration {
+	envValue := os.Getenv(envName)
+	if envValue == "" {
+		return defValue
+	}
+	parsedEnv, err := time.ParseDuration(envValue)
+	if err != nil {
+		log.Printf("Error parseing %s, invalid value: %s\n", envName, envValue)
+	}
+	return parsedEnv
+}
 
 func main() {
 	flag.Parse()

--- a/cmd/openldap_exporter/main.go
+++ b/cmd/openldap_exporter/main.go
@@ -35,6 +35,7 @@ func defaultEnvDuration(envName string, defValue time.Duration) time.Duration {
 	parsedEnv, err := time.ParseDuration(envValue)
 	if err != nil {
 		log.Printf("Error parseing %s, invalid value: %s\n", envName, envValue)
+		os.Exit(1)
 	}
 	return parsedEnv
 }


### PR DESCRIPTION
When we were using openldap_exporter we found it problematic from security point of view how the ldap username/password can be configured. We don't want to expose ldap credentials when the `ps` command is executed.

This PR introduces the ability to configure everything through environment variables. 

Kudos for your great work!