### PR TITLE
Added ldapNet parameter

### DIFF
--- a/cmd/openldap_exporter/main.go
+++ b/cmd/openldap_exporter/main.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	promAddr = "promAddr"
+	ldapNet  = "ldapNet"
 	ldapAddr = "ldapAddr"
 	ldapUser = "ldapUser"
 	ldapPass = "ldapPass"
@@ -34,6 +35,12 @@ func main() {
 			Value:   "/metrics",
 			Usage:   "Path on which to expose Prometheus metrics",
 			EnvVars: []string{"METRICS_PATH"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    ldapNet,
+			Value:   "tcp",
+			Usage:   "Network of OpenLDAP server",
+			EnvVars: []string{"LDAP_NET"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    ldapAddr,
@@ -92,7 +99,7 @@ func runMain(c *cli.Context) error {
 
 	log.Println("starting OpenLDAP scraper for", c.String(ldapAddr))
 	for range time.Tick(c.Duration(interval)) {
-		exporter.ScrapeMetrics(c.String(ldapAddr), c.String(ldapUser), c.String(ldapPass))
+		exporter.ScrapeMetrics(c.String(ldapNet), c.String(ldapAddr), c.String(ldapUser), c.String(ldapPass))
 	}
 	return nil
 }

--- a/scraper.go
+++ b/scraper.go
@@ -99,8 +99,8 @@ func objectClass(name string) string {
 	return fmt.Sprintf("(objectClass=%v)", name)
 }
 
-func ScrapeMetrics(ldapAddr, ldapUser, ldapPass string) {
-	if err := scrapeAll(ldapAddr, ldapUser, ldapPass); err != nil {
+func ScrapeMetrics(ldapNet, ldapAddr, ldapUser, ldapPass string) {
+	if err := scrapeAll(ldapNet, ldapAddr, ldapUser, ldapPass); err != nil {
 		scrapeCounter.WithLabelValues("fail").Inc()
 		log.Println("scrape failed, error is:", err)
 	} else {
@@ -108,8 +108,8 @@ func ScrapeMetrics(ldapAddr, ldapUser, ldapPass string) {
 	}
 }
 
-func scrapeAll(ldapAddr, ldapUser, ldapPass string) error {
-	l, err := ldap.Dial("tcp", ldapAddr)
+func scrapeAll(ldapNet, ldapAddr, ldapUser, ldapPass string) error {
+	l, err := ldap.Dial(ldapNet, ldapAddr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Locally used LDAP servers may support Unix Socket but no TCP. With the new option you can run the exporter like this:

`openldap_exporter --ldapNet unix --ldapAddr /var/run/openldap/ldapi`