### PR TITLE
Added replicationSearchFilter parameter

### DIFF
--- a/cmd/openldap_exporter/main.go
+++ b/cmd/openldap_exporter/main.go
@@ -87,7 +87,7 @@ func main() {
 			Name:  replicationObject,
 			Usage: "Object to watch replication upon",
 		}),
-		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:  replicationSearchFilter,
 			Usage: "Search Filter to watch replication upon, takes precedence over replicationObject",
 		}),

--- a/cmd/openldap_exporter/main.go
+++ b/cmd/openldap_exporter/main.go
@@ -16,17 +16,18 @@ import (
 )
 
 const (
-	promAddr          = "promAddr"
-	ldapNet           = "ldapNet"
-	ldapAddr          = "ldapAddr"
-	ldapUser          = "ldapUser"
-	ldapPass          = "ldapPass"
-	interval          = "interval"
-	metrics           = "metrPath"
-	jsonLog           = "jsonLog"
-	webCfgFile        = "webCfgFile"
-	config            = "config"
-	replicationObject = "replicationObject"
+	promAddr                = "promAddr"
+	ldapNet                 = "ldapNet"
+	ldapAddr                = "ldapAddr"
+	ldapUser                = "ldapUser"
+	ldapPass                = "ldapPass"
+	interval                = "interval"
+	metrics                 = "metrPath"
+	jsonLog                 = "jsonLog"
+	webCfgFile              = "webCfgFile"
+	config                  = "config"
+	replicationObject       = "replicationObject"
+	replicationSearchFilter = "replicationSearchFilter"
 )
 
 func main() {
@@ -86,6 +87,10 @@ func main() {
 			Name:  replicationObject,
 			Usage: "Object to watch replication upon",
 		}),
+		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+			Name:  replicationSearchFilter,
+			Usage: "Search Filter to watch replication upon, takes precedence over replicationObject",
+		}),
 		&cli.StringFlag{
 			Name:  config,
 			Usage: "Optional configuration from a `YAML_FILE`",
@@ -131,12 +136,13 @@ func runMain(c *cli.Context) error {
 	)
 
 	scraper := &exporter.Scraper{
-		Net:  c.String(ldapNet),
-		Addr: c.String(ldapAddr),
-		User: c.String(ldapUser),
-		Pass: c.String(ldapPass),
-		Tick: c.Duration(interval),
-		Sync: c.StringSlice(replicationObject),
+		Net:              c.String(ldapNet),
+		Addr:             c.String(ldapAddr),
+		User:             c.String(ldapUser),
+		Pass:             c.String(ldapPass),
+		Tick:             c.Duration(interval),
+		Sync:             c.StringSlice(replicationObject),
+		SyncSearchFilter: c.String(replicationSearchFilter),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/scraper.go
+++ b/scraper.go
@@ -145,9 +145,9 @@ func objectClass(name string) string {
 	return fmt.Sprintf("(objectClass=%v)", name)
 }
 
-func searchFilter(s *Scraper, name string) string {
+func syncSearchFilter(s *Scraper, name string) string {
 	if len(s.SyncSearchFilter) > 0 {
-		return fmt.Sprintf(s.SyncSearchFilter)
+		return s.SyncSearchFilter
 	} else {
 		return objectClass(name)
 	}
@@ -221,7 +221,7 @@ func (s *Scraper) addReplicationQueries() {
 		queries = append(queries,
 			&query{
 				baseDN:       q,
-				searchFilter: searchFilter(s, "*"),
+				searchFilter: syncSearchFilter(s, "*"),
 				searchAttr:   monitorReplicationFilter,
 				metric:       monitorReplicationGauge,
 				setData:      setReplicationValue,

--- a/scraper.go
+++ b/scraper.go
@@ -145,6 +145,14 @@ func objectClass(name string) string {
 	return fmt.Sprintf("(objectClass=%v)", name)
 }
 
+func searchFilter(s *Scraper, name string) string {
+	if len(s.SyncSearchFilter) > 0 {
+		return fmt.Sprintf(s.SyncSearchFilter)
+	} else {
+		return objectClass(name)
+	}
+}
+
 func setValue(entries []*ldap.Entry, q *query) {
 	for _, entry := range entries {
 		val := entry.GetAttributeValue(q.searchAttr)
@@ -197,14 +205,15 @@ func setReplicationValue(entries []*ldap.Entry, q *query) {
 }
 
 type Scraper struct {
-	Net      string
-	Addr     string
-	User     string
-	Pass     string
-	Tick     time.Duration
-	LdapSync []string
-	log      log.FieldLogger
-	Sync     []string
+	Net              string
+	Addr             string
+	User             string
+	Pass             string
+	Tick             time.Duration
+	LdapSync         []string
+	log              log.FieldLogger
+	Sync             []string
+	SyncSearchFilter string
 }
 
 func (s *Scraper) addReplicationQueries() {
@@ -212,7 +221,7 @@ func (s *Scraper) addReplicationQueries() {
 		queries = append(queries,
 			&query{
 				baseDN:       q,
-				searchFilter: objectClass("*"),
+				searchFilter: searchFilter(s, "*"),
 				searchAttr:   monitorReplicationFilter,
 				metric:       monitorReplicationGauge,
 				setData:      setReplicationValue,


### PR DESCRIPTION
Issue: https://github.com/tomcz/openldap_exporter/issues/28

In order to override the search filter i made few changes, i added `--replicationSearchFilter <value>`.  With this parameter you can override the `searchFilter:` in `addReplicationQueries()` function.

Then i can use with my use case: 

```
/usr/bin/openldap_exporter --config /etc/openldap-exporter/exporter.yaml --replicationObject "dc=my,dc=org" --replicationSearchFilter "(contextCSN=*)"
```

