### PR TITLE
doc: fix README regarding build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ NOTES:
 ## Build
 
 1. Install Go 1.20 from https://golang.org/
-2. Build the binaries: `make build`
+2. Build the binaries: `make compile`


### PR DESCRIPTION
The target of 'make build' is no longer in Makefile. Instead, developer should call 'make compile'.